### PR TITLE
Added "We will prove its Authenticity" to the "upload screenshot of acceptance email field"

### DIFF
--- a/views/addscholarform.ejs
+++ b/views/addscholarform.ejs
@@ -40,7 +40,7 @@
 
 
         <li>
-            <label class="fs-field-label fs-anim-upper" for="acceptanceEmail" data-info="This is for verification purposes only.">Upload a screenshot of your acceptance email</label>
+            <label class="fs-field-label fs-anim-upper" for="acceptanceEmail" data-info="This is for verification purposes only.">Upload a screenshot of your acceptance email (We will prove its authenticity)</label>
             <div class="fs-file-custom clearfix fs-anim-lower">
                 <input type="file" class="fs-anim-lower" id="acceptanceEmail" name="acceptanceEmail" type="text" placeholder="" required/>
             </div>


### PR DESCRIPTION
Last year some people just uploaded random images thinking everything was made by machines and they could get in like that. This should prevent them from doing that a bit.
